### PR TITLE
Update markdownlint-config.json

### DIFF
--- a/.github/workflows/markdownlint-config.json
+++ b/.github/workflows/markdownlint-config.json
@@ -3,5 +3,8 @@
   "line-length": false,
   "no-trailing-punctuation": {
     "punctuation": ".,;:"
+  },
+  "reference-links-images" : {
+    "ignored_labels": ["demo"]
   }
 }


### PR DESCRIPTION
Stops the linter crashing on the demo link