### PR TITLE
Remove `.scss` header

### DIFF
--- a/assets/style.scss
+++ b/assets/style.scss
@@ -1,8 +1,3 @@
----
-# // Default style variables for the theme; change them as you like!'
-# // NOTE: Jekyll needs this YAML header. See jekyll/jekyll#3408
----
-
 // Bring in the rest of the SASS from the theme
 
 @use "wren/initialize" with (


### PR DESCRIPTION
Rumour has it that this Jekyll hack isn't needed anymore